### PR TITLE
feat: Add webhook support for public submission events and update web…

### DIFF
--- a/app/routes/submissions.py
+++ b/app/routes/submissions.py
@@ -1,5 +1,6 @@
 """Routes for public submissions and submission management."""
 
+from datetime import datetime
 from flask import Blueprint, render_template, request, jsonify, current_app
 from flask_login import login_required, current_user
 
@@ -300,6 +301,26 @@ def public_submit():
             tags=tags,
             confidence=confidence
         )
+        
+        # Dispatch webhook for public submission
+        from app.tasks.webhook_tasks import dispatch_webhook
+        try:
+            dispatch_webhook.delay('public_submission.created', {
+                'submission_id': submission['id'],
+                'ioc_type': ioc_type,
+                'ioc_value': ioc_value,
+                'submitter_email': submitter_email,
+                'submitter_name': submitter_name,
+                'submitter_organization': submitter_organization,
+                'description': description,
+                'reason': reason,
+                'tags': tags,
+                'confidence': confidence,
+                'matched_count': len(submission.get('matched_iocs', [])),
+                'timestamp': datetime.utcnow().isoformat()
+            })
+        except Exception as e:
+            current_app.logger.warning(f"Failed to dispatch webhook for public submission: {str(e)}")
         
         # Log successful submission
         audit.log(

--- a/app/routes/webhook.py
+++ b/app/routes/webhook.py
@@ -18,7 +18,8 @@ WEBHOOK_EVENTS = [
     'ioc.created',
     'ioc.updated',
     'ioc.deleted',
-    'import.completed'
+    'import.completed',
+    'public_submission.created'
 ]
 
 

--- a/templates/settings/webhooks.html
+++ b/templates/settings/webhooks.html
@@ -147,6 +147,12 @@
                                 Import Completed
                             </label>
                         </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="eventPublicSubmission" value="public_submission.created">
+                            <label class="form-check-label" for="eventPublicSubmission">
+                                Public Submission Created
+                            </label>
+                        </div>
                     </div>
                     
                     <div class="mb-3">


### PR DESCRIPTION
This pull request adds support for dispatching webhooks when a new public submission is created. The main changes include triggering the webhook on submission, updating the list of supported webhook events, and adding an option in the webhooks settings UI for users to select this event.

Webhook dispatch and event support:

* Added logic to dispatch a `public_submission.created` webhook event after a successful public submission, including relevant submission details and a UTC timestamp.
* Updated the supported webhook events list to include `public_submission.created` in `app/routes/webhook.py`.

User interface updates:

* Added a checkbox for the "Public Submission Created" event in the webhooks settings modal (`templates/settings/webhooks.html`), allowing users to subscribe to this new event.

Other changes:

* Imported `datetime` in `app/routes/submissions.py` to support timestamping webhook payloads.…hook settings UI